### PR TITLE
Update retroarch-003-fix-sdl-screenlock.patch

### DIFF
--- a/package/retroarch/retroarch-003-fix-sdl-screenlock.patch
+++ b/package/retroarch/retroarch-003-fix-sdl-screenlock.patch
@@ -1,7 +1,44 @@
-diff -ruN retroarch-v1.7.3_orig/gfx/drivers/sdl_gfx.c retroarch-v1.7.3/gfx/drivers/sdl_gfx.c
---- retroarch-v1.7.3_orig/gfx/drivers/sdl_gfx.c	2018-05-03 21:45:22.000000000 -0600
-+++ retroarch-v1.7.3/gfx/drivers/sdl_gfx.c	2018-11-17 22:38:40.012476123 -0700
-@@ -361,13 +361,6 @@
+gfx.c ./new/sdl_gfx.c
+--- ./orig/sdl_gfx.c 2022-10-22 09:52:49.000000000 +0100
++++ ./new/sdl_gfx.c	2022-10-22 09:57:03.000000000 +0100
+
+@@ -336,20 +336,29 @@
+       unsigned height, uint64_t frame_count,
+       unsigned pitch, const char *msg, video_frame_info_t *video_info)
+ {
+-   sdl_video_t                    *vid = (sdl_video_t*)data;
+    char title[128];
++   sdl_video_t                    *vid = (sdl_video_t*)data;
++#ifdef HAVE_MENU
++   bool menu_is_alive                  = video_info->menu_is_alive;
++#endif
+ 
+    if (!frame)
+       return true;
+ 
+-   title[0] = '\0';
++   //title[0] = '\0';
+ 
+-   video_driver_get_window_title(title, sizeof(title));
++   //video_driver_get_window_title(title, sizeof(title));
+ 
+-   if (SDL_MUSTLOCK(vid->screen))
+-      SDL_LockSurface(vid->screen);
++   if (vid->menu.active) {
++      #ifdef HAVE_MENU
++         menu_driver_frame(menu_is_alive, video_info);
++      #endif
++      SDL_BlitSurface(vid->menu.frame, NULL, vid->screen, NULL);
++   } else {
++      if (SDL_MUSTLOCK(vid->screen))
++        SDL_LockSurface(vid->screen);
+ 
+-   video_frame_scale(
++       video_frame_scale(
+          &vid->scaler,
+          vid->screen->pixels,
+          frame,
+@@ -361,22 +370,15 @@
           height,
           pitch);
  
@@ -12,20 +49,22 @@ diff -ruN retroarch-v1.7.3_orig/gfx/drivers/sdl_gfx.c retroarch-v1.7.3/gfx/drive
 -   if (vid->menu.active)
 -      SDL_BlitSurface(vid->menu.frame, NULL, vid->screen, NULL);
 -
-    if (msg)
-       sdl_render_msg(vid, vid->screen,
-             msg, vid->screen->w, vid->screen->h, vid->screen->format);
-@@ -375,6 +368,13 @@
-    if (SDL_MUSTLOCK(vid->screen))
-       SDL_UnlockSurface(vid->screen);
+-   if (msg)
+-      sdl_render_msg(vid, vid->screen,
+-            msg, vid->screen->w, vid->screen->h, vid->screen->format);
++       if (msg)
++         sdl_render_msg(vid, vid->screen, msg, vid->screen->w, vid->screen->h, vid->screen->format);
  
-+#ifdef HAVE_MENU
-+   menu_driver_frame(video_info);
-+#endif
-+
-+   if (vid->menu.active)
-+      SDL_BlitSurface(vid->menu.frame, NULL, vid->screen, NULL);
-+
-    if (title[0])
-       SDL_WM_SetCaption(title, NULL);
+-   if (SDL_MUSTLOCK(vid->screen))
+-      SDL_UnlockSurface(vid->screen);
++    if (SDL_MUSTLOCK(vid->screen))
++       SDL_UnlockSurface(vid->screen);
++  }
  
+-   if (title[0])
+-      SDL_WM_SetCaption(title, NULL);
++//   if (title[0])
++//      SDL_WM_SetCaption(title, NULL);
+ 
+    SDL_Flip(vid->screen);
+


### PR DESCRIPTION
Incorporates the original fix whilst also fixing this for LF1000 build, stopping the flickering on this platform.  This was being caused by the menu and game video being written to the surface at the same time regardless of which one was active.  Also commented out Window code which is irrelevant to the platform.